### PR TITLE
Fix bug where JSON database cleared

### DIFF
--- a/PSDatabaseClone/functions/image/Remove-PSDCImage.ps1
+++ b/PSDatabaseClone/functions/image/Remove-PSDCImage.ps1
@@ -272,16 +272,13 @@
                         }
                     }
                     elseif ($informationStore -eq 'File') {
-                        $imageData = Get-PSDCImage
-                        [array]$newImageData = $null
-
-                        $imageData = $imageData | Where-Object {$_.ImageID -ne $item.ImageID}
+                        $imageData = Get-PSDCImage | Where-Object {$_.ImageID -ne $item.ImageID}
 
                         # Set the image file
                         $jsonImageFile = "PSDCJSONFolder:\images.json"
 
                         # Convert the data back to JSON
-                        if ($newImageData.Count -ge 1) {
+                        if ($imageData) {
                             $imageData | ConvertTo-Json | Set-Content $jsonImageFile
                         }
                         else {


### PR DESCRIPTION
When using the Remove-PSDCImage function, the JSON database gets cleared because the $newImageData variable is never set.