### PR TITLE
Include memory-optimized files

### DIFF
--- a/PSDatabaseClone/functions/clone/New-PSDCClone.ps1
+++ b/PSDatabaseClone/functions/clone/New-PSDCClone.ps1
@@ -510,10 +510,10 @@
 
                 # Get all the files of the database
                 if ($computer.IsLocalhost) {
-                    $databaseFiles = Get-ChildItem -Path $accessPath -Recurse | Where-Object {-not $_.PSIsContainer}
+                    $databaseFiles = Get-ChildItem -Path $accessPath -Filter *.*df -Recurse
                 }
                 else {
-                    $commandText = "Get-ChildItem -Path '$accessPath' -Recurse | " + 'Where-Object {-not $_.PSIsContainer}'
+                    $commandText = "Get-ChildItem -Path '$accessPath' -Filter *.*df -Recurse"
                     $command = [ScriptBlock]::Create($commandText)
                     $databaseFiles = Invoke-PSFCommand -ComputerName $computer -ScriptBlock $command -Credential $Credential
                 }


### PR DESCRIPTION
Memory-optimized files in SQL are actually folders with a .mdf extension instead of files.  A stricter search could look for only .mdf and .ldf files/folders, but wouldn't be able to take advantage of the performance of the -Filter option.