### PR TITLE
Fix Image Backup error

### DIFF
--- a/PSDatabaseClone/functions/image/New-PSDCImage.ps1
+++ b/PSDatabaseClone/functions/image/New-PSDCImage.ps1
@@ -390,7 +390,16 @@
                 Write-PSFMessage -Message "Trying to retrieve the last full backup for $db" -Level Verbose
 
                 # Get the last full backup
-                $lastFullBackup = Get-DbaBackupHistory -SqlServer $SourceSqlInstance -SqlCredential $SourceSqlCredential -Databases $db.Name -LastFull
+                $lastFullBackup = Get-DbaBackupHistory -SqlInstance $SourceSqlInstance -SqlCredential $SourceSqlCredential -Database $db.Name -LastFull
+            }
+
+            if($lastFullBackup.Path.Length -le 1){
+                Stop-PSFFunction -Message "No full backup could be found. Please use -CreateFullBackup or create a full backup manually" -Target $lastFullBackup
+                return
+            }
+            elseif(-not (Test-Path -Path $lastFullBackup.Path)){
+                Stop-PSFFunction -Message "Could not access the full backup file. Check if it exists or that you have enough privileges to access it" -Target $lastFullBackup
+                return
             }
 
             if ($PSCmdlet.ShouldProcess("$imageName", "Creating the vhd")) {

--- a/PSDatabaseClone/functions/image/New-PSDCImage.ps1
+++ b/PSDatabaseClone/functions/image/New-PSDCImage.ps1
@@ -386,14 +386,14 @@
                     $lastFullBackup = Backup-DbaDatabase -SqlInstance $SourceSqlInstance -SqlCredential $SourceSqlCredential -Database $db.Name -CopyOnly:$CopyOnlyBackup
                 }
             }
-            elseif ($UseLastFullBackup) {
+            else{
                 Write-PSFMessage -Message "Trying to retrieve the last full backup for $db" -Level Verbose
 
                 # Get the last full backup
                 $lastFullBackup = Get-DbaBackupHistory -SqlInstance $SourceSqlInstance -SqlCredential $SourceSqlCredential -Database $db.Name -LastFull
             }
 
-            if($lastFullBackup.Path.Length -le 1){
+            if(-not $lastFullBackup.Path){
                 Stop-PSFFunction -Message "No full backup could be found. Please use -CreateFullBackup or create a full backup manually" -Target $lastFullBackup
                 return
             }


### PR DESCRIPTION
When no full backup was assigned the command could fail if it couldn't find the backup file.

The command now checks the availability of the full backup