### PR TITLE
Trim the windows edition string before lookup

### DIFF
--- a/internal/scripts/preimport.ps1
+++ b/internal/scripts/preimport.ps1
@@ -18,7 +18,7 @@ $supportedVersions = @(
 # Get the OS details
 $osDetails = Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Description, Name, OSType, Version
 
-$windowsEdition = ($osDetails.Caption).Replace("Evaluation", "")
+$windowsEdition = ($osDetails.Caption).Replace(" Evaluation", "").Trim()
 
 # Check which version of windows we're dealing with
 if ($windowsEdition -notin $supportedVersions ) {


### PR DESCRIPTION
This will ensure any additional whitespace is removed, which can cause issues when looking up the edition in the supported array