### PR TITLE
Removes default value for $InformationStore, as well as checks to see if path is available before using it

### DIFF
--- a/functions/support/Set-PSDCConfiguration.ps1
+++ b/functions/support/Set-PSDCConfiguration.ps1
@@ -88,7 +88,7 @@
 
     param(
         [ValidateSet('SQL', 'File')]
-        [string]$InformationStore = 'File',
+        [string]$InformationStore,
         [parameter(ParameterSetName = "SQL", Mandatory = $true)]
         [DbaInstanceParameter]$SqlInstance,
         [parameter(ParameterSetName = "SQL")]
@@ -215,7 +215,7 @@
             return
         }
 
-        if (-not (Test-Path -Path $Path)) {
+        if ($Path -and -not (Test-Path -Path $Path)) {
             try {
                 $null = New-Item -Path $Path -ItemType Directory -Confirm:$false -Force
             }

--- a/internal/scripts/preimport.ps1
+++ b/internal/scripts/preimport.ps1
@@ -18,7 +18,7 @@ $supportedVersions = @(
 # Get the OS details
 $osDetails = Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Description, Name, OSType, Version
 
-$windowsEdition = ($osDetails.Caption).Replace("Evaluation", "")
+$windowsEdition = ($osDetails.Caption).Replace(" Evaluation", "").Trim()
 
 # Check which version of windows we're dealing with
 if ($windowsEdition -notin $supportedVersions ) {

--- a/internal/scripts/preimport.ps1
+++ b/internal/scripts/preimport.ps1
@@ -18,9 +18,11 @@ $supportedVersions = @(
 # Get the OS details
 $osDetails = Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Description, Name, OSType, Version
 
+$windowsEdition = ($osDetails.Caption).Replace("Evaluation", "")
+
 # Check which version of windows we're dealing with
-if ($osDetails.Caption -notin $supportedVersions ) {
-    if ($osDetails.Caption -like '*Windows 7*') {
+if ($windowsEdition -notin $supportedVersions ) {
+    if ($windowsEdition -like '*Windows 7*') {
         Stop-PSFFunction -Message "Module does not work on Windows 7" -Target $OSDetails -FunctionName 'Pre Import'
     }
     else {


### PR DESCRIPTION
This should fix #72

`$InformationStore` was recieving a default value of `'File'`. Because of this, this line wasn't functioning correctly:

```
if ($InputPrompt -or (-not $InformationStore) -and (-not $SqlInstance -and -not $SqlCredential -and -not $Credential -and -not $Database)) {
```

The above condition determines if we enter into the interactive prompt. We do so if `$InputPrompt` is true, or if we don't have any values for `$InformationStore`. Since we don't provide either, but `$InformationStore` was being defaulted, the script never entered into the conditional block.

Additionally, there was an issue of `$Path` variable being operated on when there was not path variable (for example, database store). I made a quick fix just to make sure we have `$Path` before using it. That being said, a quick glance over the code reveals that the logic for this stuff in general could probably be improved upon - Couple of examples:

* In the prompt itself, we have the path being saved as `$filePath`, and at the end we never set `$Path = $filePath`. 
* We do some remote commands on the interactive prompt path, whereas the literal parameter Path doesn't have the same commands done with it.
* When not doing interactive prompt, we create the path if it doesn't exist, but in the prompt we simply error out.

We can probably consolidate a bunch of this stuff and better organize it, but curious what @sanderstad thinks. But for now, these simple tweaks will at least take care of a couple bugs.
