### PR TITLE
Docker support

### DIFF
--- a/functions/clone/New-PSDCClone.ps1
+++ b/functions/clone/New-PSDCClone.ps1
@@ -792,12 +792,19 @@
                     $clones | ConvertTo-Json | Set-Content $jsonCloneFile
                 }
 
+                if(-not $SkipDatabaseMount){
+                    $cloneInstance = $server.DomainInstanceName
+                }
+                else{
+                    $cloneInstance = $null
+                }
+
                 # Add the results to the custom object
                 [PSCustomObject]@{
                     CloneID       = $cloneID
                     CloneLocation = $cloneLocation
                     AccessPath    = $accessPath
-                    SqlInstance   = $server.DomainInstanceName
+                    SqlInstance   = $cloneInstance
                     DatabaseName  = $cloneDatabase
                     IsEnabled     = $active
                     ImageID       = $image.ImageID

--- a/functions/clone/New-PSDCClone.ps1
+++ b/functions/clone/New-PSDCClone.ps1
@@ -164,9 +164,17 @@
             }
         }
 
-        if (-not $SqlInstance -and $SkipDatabaseMount) {
-            [array]$SqlInstance = "None"
+        if ($SkipDatabaseMount) {
+            if (-not $SqlInstance) {
+                [array]$SqlInstance = "None"
+            }
+
+            if(-not $Destination){
+                Stop-PSFFunction -Message "Please enter a destination when using -SkipDatabaseMount" -Continue
+            }
         }
+
+
 
         # Check the available images
         $images = Get-PSDCImage
@@ -195,11 +203,11 @@
             }
 
             # Setup the computer object
-            $computer = [PsfComputer]$server.ComputerName
+            $computer = [PsfComputer]$instance.ComputerName
 
             if (-not $computer.IsLocalhost) {
                 # Get the result for the remote test
-                $resultPSRemote = Test-PSDCRemoting -ComputerName $server.Name -Credential $Credential
+                $resultPSRemote = Test-PSDCRemoting -ComputerName $computer.ComputerName -Credential $Credential
 
                 # Check the result
                 if ($resultPSRemote.Result) {

--- a/functions/clone/Remove-PSDCClone.ps1
+++ b/functions/clone/Remove-PSDCClone.ps1
@@ -214,6 +214,7 @@
                 }
 
                 $server = Connect-DbaInstance -SqlInstance $item.SqlInstance -SqlCredential $SqlCredential
+
                 if ($item.DatabaseName -in $server.Databases.Name) {
                     if ($PSCmdlet.ShouldProcess($item.DatabaseName, "Removing database $($item.DatabaseName)")) {
                         # Remove the database
@@ -228,7 +229,7 @@
                     }
                 }
                 else {
-                    Write-PSFMessage -Level Verbose -Message "COuld not find database [$($item.DatabaseName)] on $item.SqlInstance"
+                    Write-PSFMessage -Level Verbose -Message "Could not find database [$($item.DatabaseName)] on $($item.SqlInstance)"
                 }
 
                 if ($PSCmdlet.ShouldProcess($item.CloneLocation, "Dismounting the vhd")) {

--- a/functions/clone/Remove-PSDCClone.ps1
+++ b/functions/clone/Remove-PSDCClone.ps1
@@ -235,16 +235,20 @@
                 if ($PSCmdlet.ShouldProcess($item.CloneLocation, "Dismounting the vhd")) {
                     # Dismounting the vhd
                     try {
-
-                        if ($computer.IsLocalhost) {
-                            $null = Dismount-DiskImage -ImagePath $item.CloneLocation
+                        if (Test-Path -Path $item.CloneLocation) {
+                            if ($computer.IsLocalhost) {
+                                $null = Dismount-DiskImage -ImagePath $item.CloneLocation
+                            }
+                            else {
+                                $command = [ScriptBlock]::Create("Test-Path -Path '$($item.CloneLocation)'")
+                                Write-PSFMessage -Message "Dismounting disk '$($item.CloneLocation)' from $($item.HostName)" -Level Verbose
+                                $result = Invoke-PSFCommand -ComputerName $item.HostName -ScriptBlock $command -Credential $Credential
+                                $command = [scriptblock]::Create("Dismount-DiskImage -ImagePath '$($item.CloneLocation)'")
+                                $null = Invoke-PSFCommand -ComputerName $item.HostName -ScriptBlock $command -Credential $Credential
+                            }
                         }
                         else {
-                            $command = [ScriptBlock]::Create("Test-Path -Path '$($item.CloneLocation)'")
-                            Write-PSFMessage -Message "Dismounting disk '$($item.CloneLocation)' from $($item.HostName)" -Level Verbose
-                            $result = Invoke-PSFCommand -ComputerName $item.HostName -ScriptBlock $command -Credential $Credential
-                            $command = [scriptblock]::Create("Dismount-DiskImage -ImagePath '$($item.CloneLocation)'")
-                            $null = Invoke-PSFCommand -ComputerName $item.HostName -ScriptBlock $command -Credential $Credential
+                            Write-PSFMessage -Level Verbose -Message "Could not find clone file '$($item.CloneLocation)'"
                         }
                     }
                     catch {

--- a/functions/image/New-PSDCImage.ps1
+++ b/functions/image/New-PSDCImage.ps1
@@ -111,7 +111,6 @@
         The image is written to c:\Temp\images
     #>
     [CmdLetBinding(SupportsShouldProcess = $true)]
-    [OutputType('PSDCImage')]
 
     param(
         [parameter(Mandatory = $true)]


### PR DESCRIPTION
For the use with docker the database should not be mounted after the clone has been made.
This way the user can reference the shared folder and let the docker sql server open the database files

A lot of extra checks were added and the possibility for not having an instance name in the clone record was implemented.

