### PR TITLE
Fixes clone creation command - Get-Disk doesn't retun Location parameter

### DIFF
--- a/functions/clone/New-PSDCClone.ps1
+++ b/functions/clone/New-PSDCClone.ps1
@@ -426,7 +426,8 @@
                             $null = Mount-DiskImage -ImagePath "$($clonePath)"
 
                             # Get the disk based on the name of the vhd
-                            $disk = Get-Disk | Where-Object { $_.Location -eq "$($clonePath)" }
+                            $diskImage = Get-DiskImage -ImagePath $clonePath
+                            $disk = Get-Disk | Where-Object Number -eq $diskImage.Number
                         }
                         else {
                             # Mount the disk

--- a/functions/disk/Initialize-PSDCVhdDisk.ps1
+++ b/functions/disk/Initialize-PSDCVhdDisk.ps1
@@ -92,31 +92,34 @@
         # Test if there are any errors
         if (Test-PSFFunctionInterrupt) { return }
 
-        # Check if disk is already mounted
-        $diskImage = Get-DiskImage -ImagePath $Path
+        # Get all the disks
+        $disks = Get-Disk
 
         # Check if disk is already mounted
-        if ($disks) {
+        if ($disks.Location -contains $Path) {
             Write-PSFMessage -Message "Vhd is already mounted" -Level Warning
+
+            # retrieve the specific disk
+            $disk = $disks | Where-Object Location -eq $Path
         }
         else {
             if ($PSCmdlet.ShouldProcess("Mounting disk")) {
                 # Mount the vhd
                 try {
                     Write-PSFMessage -Message "Mounting disk $disk" -Level Verbose
- 
+
                     # Mount the disk
                     Mount-DiskImage -ImagePath $Path
+
+                    # Get the disk
                     $diskImage = Get-DiskImage -ImagePath $Path
+                    $disk = Get-Disk | Where-Object Number -eq $diskImage.Number
                 }
                 catch {
                     Stop-PSFFunction -Message "Couldn't mount vhd" -Target $Path -ErrorRecord $_ -Continue
                 }
             }
         }
-
-        # Get the mounted disk
-        $disk = Get-Disk | Where-Object Number -eq $diskImage.Number
 
         if ($PSCmdlet.ShouldProcess("Initializing disk")) {
             # Check if the disk is already initialized

--- a/functions/disk/Initialize-PSDCVhdDisk.ps1
+++ b/functions/disk/Initialize-PSDCVhdDisk.ps1
@@ -92,34 +92,31 @@
         # Test if there are any errors
         if (Test-PSFFunctionInterrupt) { return }
 
-        # Get all the disks
-        $disks = Get-Disk
+        # Check if disk is already mounted
+        $diskImage = Get-DiskImage -ImagePath $Path
 
         # Check if disk is already mounted
-        if ($disks.Location -contains $Path) {
+        if ($disks) {
             Write-PSFMessage -Message "Vhd is already mounted" -Level Warning
-
-            # retrieve the specific disk
-            $disk = $disks | Where-Object Location -eq $Path
         }
         else {
             if ($PSCmdlet.ShouldProcess("Mounting disk")) {
                 # Mount the vhd
                 try {
                     Write-PSFMessage -Message "Mounting disk $disk" -Level Verbose
-
+ 
                     # Mount the disk
                     Mount-DiskImage -ImagePath $Path
-
-                    # Get the disk
                     $diskImage = Get-DiskImage -ImagePath $Path
-                    $disk = Get-Disk | Where-Object Number -eq $diskImage.Number
                 }
                 catch {
                     Stop-PSFFunction -Message "Couldn't mount vhd" -Target $Path -ErrorRecord $_ -Continue
                 }
             }
         }
+
+        # Get the mounted disk
+        $disk = Get-Disk | Where-Object Number -eq $diskImage.Number
 
         if ($PSCmdlet.ShouldProcess("Initializing disk")) {
             # Check if the disk is already initialized


### PR DESCRIPTION
Resolves #82.

Was running into the same issue with the clone command as I did with the image command, in that `Get-Disk` did not provide `Location` property for mounted disks. 

---

Update: I reverted this as it didn't work as I expected. But might be useful to keep these data around as it is something that would need to be fixed 😄 

Additionally, I fixed the New Image command to bypass the Location parameter during the mounted check.

@sanderstad You might want to look at this bit of code in the New-PSDCClone function:

```
else {
                            # Mount the disk
                            $command = [ScriptBlock]::Create("Mount-DiskImage -ImagePath `"$($clonePath)`"")
                            $null = Invoke-PSFCommand -ComputerName $computer -ScriptBlock $command -Credential $Credential

                            # Get the disk based on the name of the vhd
                            $command = [ScriptBlock]::Create("Get-Vhd -Path `"$($clonePath)`"")
                            $disk = Invoke-PSFCommand -ComputerName $computer -ScriptBlock $command -Credential $Credential
                        }
```

The change I made only affects the localhost part, whereas this code is for the remote part. I apparently don't even have a `Get-Vhd` on my system, and since this deals with remote management (something I haven't myself tested), I figured you might want to look at it to see if it needs any updating that you can tell to incorporate this  change. 😄 